### PR TITLE
[Bug/#33] 빽도를 처리할 수 없는 경우 낙 처리

### DIFF
--- a/src/controller/YutController.java
+++ b/src/controller/YutController.java
@@ -42,7 +42,7 @@ public class YutController {
             YutResult result = game.throwYut();
             board.updateResultList(game.getYutResults());
 
-            if (game.getYutResults().size() == 1 && game.getYutResults().get(0) == YutResult.BackDo
+            if (game.getYutResults().get(0) == YutResult.BackDo
                     && game.getCurrentPlayer().getPieces().stream().allMatch(p -> {
                 int[] pos = p.getPosition();
                 return pos.length == 0 || (pos[0] == 0 && pos[1] == 0);
@@ -107,7 +107,7 @@ public class YutController {
                             System.out.println("이 pieces는 이미 종료되었습니다.");
                         }
                         else {
-                            if (game.getYutResults().size() == 1 && game.getYutResults().get(0) == YutResult.BackDo
+                            if (game.getYutResults().get(0) == YutResult.BackDo
                                     && game.getCurrentPlayer().getPieces().stream().allMatch(p -> {
                                 int[] pos = p.getPosition();
                                 return pos.length == 0 || (pos[0] == 0 && pos[1] == 0);
@@ -141,7 +141,7 @@ public class YutController {
         game.setManualYutResult(result);
         board.updateResultList(game.getYutResults());
 
-        if (game.getYutResults().size() == 1 && game.getYutResults().get(0) == YutResult.BackDo
+        if (game.getYutResults().get(0) == YutResult.BackDo
                 && game.getCurrentPlayer().getPieces().stream().allMatch(p -> {
             int[] pos = p.getPosition();
             return pos.length == 0 || (pos[0] == 0 && pos[1] == 0);
@@ -213,7 +213,6 @@ public class YutController {
                     System.out.println(btn.getYutResult() + "으로 이동 후 말의 위치: [" + selectedPiece.getPosition()[0] + ", " + selectedPiece.getPosition()[1] + "]");
                     game.consumeResult();
                     board.updateResultList(game.getYutResults());
-
 
                     if (!game.hasRemainingMoves()) {
                         if (!game.getYutResults().isEmpty() &&


### PR DESCRIPTION
## 🔀 Pull Request Title

빽도 처리할 수 없는 경우 낙 처리

---

## 📌 PR 설명

윷을 던졌을 때 빽도가 처음으로 나오고, 현재 사용자의 말들이 해당 빽도를 처리할 수 없는 경우 낙 처리
낙 처리 후 사용자의 턴을 넘김

---

## 📷 스크린샷 (if applicable)

If there are UI changes, please include relevant screenshots.
UI 변경이 있을 경우 스크린샷을 첨부해주세요.

---

## 🔍 추가 설명

Add any other context, tips for the reviewer, or special considerations here.
리뷰어가 알아야 할 추가 정보나 요청사항이 있다면 적어주세요.