### PR TITLE
style(#59): 윷놀이판 오른쪽 부분 위치 다시 되돌리기 (윈도우 이슈)

### DIFF
--- a/src/view/YutBoardV2.java
+++ b/src/view/YutBoardV2.java
@@ -31,11 +31,11 @@ public class YutBoardV2 extends JPanel {
         setLayout(null);
 
         throwButton = new JButton("랜덤 윷 던지기");
-        throwButton.setBounds(605, 370, 300, 45);
+        throwButton.setBounds(605, 370, 360, 45);
         add(throwButton);
 
         int y = 420;
-        int w = 50;
+        int w = 60;
         int h = 35;
 
         throwBackdo = new JButton("빽도");
@@ -43,23 +43,23 @@ public class YutBoardV2 extends JPanel {
         add(throwBackdo);
 
         throwDo = new JButton("도");
-        throwDo.setBounds(655, y, w, h);
+        throwDo.setBounds(665, y, w, h);
         add(throwDo);
 
         throwGae = new JButton("개");
-        throwGae.setBounds(705, y, w, h);
+        throwGae.setBounds(725, y, w, h);
         add(throwGae);
 
         throwGeol = new JButton("걸");
-        throwGeol.setBounds(755, y, w, h);
+        throwGeol.setBounds(785, y, w, h);
         add(throwGeol);
 
         throwYut = new JButton("윷");
-        throwYut.setBounds(805, y, w, h);
+        throwYut.setBounds(845, y, w, h);
         add(throwYut);
 
         throwMo = new JButton("모");
-        throwMo.setBounds(855, y, w, h);
+        throwMo.setBounds(905, y, w, h);
         add(throwMo);
 
         endPiece = new JButton("내보내기");


### PR DESCRIPTION
## 🔀 Pull Request Title

윷놀이판 오른쪽 부분 위치 다시 되돌리기 (윈도우 이슈)

---

## 📌 PR 설명

윷놀이판 오른쪽 부분 위치 다시 되돌리기 (윈도우 이슈)

---

## 📷 스크린샷 (if applicable)

If there are UI changes, please include relevant screenshots.
UI 변경이 있을 경우 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/a9fac109-1053-4647-9886-42da68e654bf)

---

## 🔍 추가 설명

Add any other context, tips for the reviewer, or special considerations here.
리뷰어가 알아야 할 추가 정보나 요청사항이 있다면 적어주세요.